### PR TITLE
Adding Amarna and Caracal

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Xmind Link: https://xmind.works/share/zfdeD07U
 - [smartcheck](https://github.com/smartdec/smartcheck)
 - [solidityscan.com](https://solidityscan.com/)
 - [Fuzzinglab’s Octopus](https://github.com/FuzzingLabs/octopus)
+- [Caracal](https://github.com/crytic/caracal)
+- [Amarna](https://github.com/crytic/amarna)
 
 ### Auditing Books and Guides:
 


### PR DESCRIPTION
Amarna and Caracal are static analysis tools for Cairo smart contracts on built on Snarknet